### PR TITLE
Use the user's real name if available

### DIFF
--- a/panel/applets/status/StatusApplet.vala
+++ b/panel/applets/status/StatusApplet.vala
@@ -158,7 +158,10 @@ public class StatusAppletImpl : Budgie.Applet
         grid.attach(user_img, 0, row, 1, 1);
 
         /* clickable username.. change account options */
-        label = new Gtk.Button.with_label(Environment.get_user_name());
+        string? username = Environment.get_real_name();
+        if (username == "Unknown")
+            username = Environment.get_user_name();
+        label = new Gtk.Button.with_label(username);
         label.clicked.connect(()=> {
             popover.hide();
             try {

--- a/panel/applets/status/StatusApplet.vala
+++ b/panel/applets/status/StatusApplet.vala
@@ -158,9 +158,10 @@ public class StatusAppletImpl : Budgie.Applet
         grid.attach(user_img, 0, row, 1, 1);
 
         /* clickable username.. change account options */
-        string? username = Environment.get_real_name();
-        if (username == "Unknown")
+        string username = Environment.get_real_name();
+        if (username == "Unknown") {
             username = Environment.get_user_name();
+        }
         label = new Gtk.Button.with_label(username);
         label.clicked.connect(()=> {
             popover.hide();


### PR DESCRIPTION
If the user has set his/her name, then the status applet should use that instead of the username. If it is not available, then the  username will be used, just like before.