### PR TITLE
specify DesktopNames field in .desktop - refers #155

### DIFF
--- a/data/budgie-desktop.desktop.in
+++ b/data/budgie-desktop.desktop.in
@@ -5,3 +5,4 @@ Exec=@prefix@/bin/budgie-session
 TryExec=@prefix@/bin/budgie-session
 Icon=
 Type=Application
+DesktopNames=Budgie;GNOME


### PR DESCRIPTION
More specifically:
 https://github.com/evolve-os/budgie-desktop/issues/155#issuecomment-73356841

It is really useful on Ubuntu based distributions.